### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/nixpkgs_pytools/format.py
+++ b/nixpkgs_pytools/format.py
@@ -50,7 +50,7 @@ def format_license(license):
        import json
        from collections import defaultdict
 
-       projects = {r['project'] for r in requests.get("https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.json").json()['rows']}
+       projects = {r['project'] for r in requests.get("https://hugovk.github.io/top-pypi-packages/top-pypi-packages.json").json()['rows']}
        licenses = defaultdict(lambda:0)
        for p in projects:
            try:


### PR DESCRIPTION
To stay within quota, it now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.